### PR TITLE
feat: use rekor monitor workflow

### DIFF
--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -1,6 +1,9 @@
 name: Rekor Monitor
 
 on:
+  push:
+    branches:
+      - monitor
   schedule:
     - cron: '0 * * * *' # hourly
 
@@ -8,16 +11,48 @@ env:
   GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
 
 jobs:
+  identities:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      identities: ${{ steps.workflow.outputs.workflow-identities }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get Workflow Identities
+        id: workflow
+        env:
+          GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          workflows=$(find ./.github/workflows -type f -name '*.yaml' -not \( -name rekor-monitor.yaml \))
+
+          echo 'workflow-identities<<EOF' >> $GITHUB_OUTPUT
+          while read workflow; do
+            workflowName=$(basename "${workflow}")
+            echo "${GITHUB_SERVER_URL}/${REPO}/.github/workflows/${workflowName}@refs/heads/main ${GITHUB_ACTIONS_ISSUER}" >> $GITHUB_OUTPUT
+          done <<< "${workflows}"
+
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+  debug:
+    runs-on: ubuntu-latest
+    needs: [identities]
+    steps:
+      - run: |
+          echo "${{ needs.identities.outputs.identities }}"
+
   run-consistency-proof:
     permissions:
       contents: read
       issues: write
       id-token: write
+    needs: [debug]
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yaml@main
     with:
       file_issue: true
       artifact_retention_days: 14
       identities: |
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER
+        ${{ needs.identities.outputs.identities }}

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -50,7 +50,7 @@ jobs:
       issues: write
       id-token: write
     needs: [debug]
-    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yaml@main
+    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true
       artifact_retention_days: 14

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -42,14 +42,15 @@ jobs:
     needs: [identities]
     steps:
       - run: |
-          echo "${{ needs.identities.outputs.identities }}"
+          printf "${{ needs.identities.outputs.identities }}" > identities.txt
+          cat identities.txt
 
   run-consistency-proof:
     permissions:
       contents: read
       issues: write
       id-token: write
-    needs: [debug]
+    needs: [identities]
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -1,9 +1,6 @@
 name: Rekor Monitor
 
 on:
-  push:
-    branches:
-      - monitor
   schedule:
     - cron: '0 * * * *' # hourly
 

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -1,0 +1,20 @@
+name: Rekor Monitor
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+
+jobs:
+  consistency-proof:
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yaml@main
+    with:
+      file_issue: true
+      artifact_retention_days: 14
+      identities: |
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refs/heads/main https://token.actions.githubusercontent.com
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refs/heads/main https://token.actions.githubusercontent.com
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refs/heads/main https://token.actions.githubusercontent.com

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -4,8 +4,11 @@ on:
   schedule:
     - cron: '0 * * * *' # hourly
 
+env:
+  GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
+
 jobs:
-  consistency-proof:
+  run-consistency-proof:
     permissions:
       contents: read
       issues: write
@@ -15,6 +18,6 @@ jobs:
       file_issue: true
       artifact_retention_days: 14
       identities: |
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refs/heads/main https://token.actions.githubusercontent.com
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refs/heads/main https://token.actions.githubusercontent.com
-        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refs/heads/main https://token.actions.githubusercontent.com
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER
+        https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refs/heads/main $GITHUB_ACTIONS_ISSUER

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -37,14 +37,6 @@ jobs:
 
           echo 'EOF' >> $GITHUB_OUTPUT
 
-  debug:
-    runs-on: ubuntu-latest
-    needs: [identities]
-    steps:
-      - run: |
-          printf "${{ needs.identities.outputs.identities }}" > identities.txt
-          cat identities.txt
-
   run-consistency-proof:
     permissions:
       contents: read


### PR DESCRIPTION
This will run [consistency proofs](https://transparency.dev/verifiable-data-structures/) against the public good Rekor instance, as well as generate a list of log entries created by the identities we're monitoring (only entries that were generated since the last run). 

Example run: https://github.com/liatrio/gh-trusted-builds-workflows/actions/runs/5093719007