### PR TITLE
feat: docker image sbom

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -175,6 +175,7 @@ jobs:
         with:
           context: .
           push: false
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/image.tar

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -178,7 +178,7 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/image.tar
+          outputs: type=oci,dest=/tmp/image.tar
 
       - name: Upload Image Archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          syft attest -o spdx-json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+          syft ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
   build:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -110,7 +110,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: anchore/download-syft@v0
+      - uses: anchore/sbom-action/download-syft@v0
         with:
           syft-version: ${{ inputs.syftVersion }}
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,6 +23,10 @@ on:
         description: "SLSA container provenance generator version"
         default: "1.6.0"
         type: string
+      syftVersion:
+        description: "Anchore syft version"
+        default: "v0.82.0"
+        type: string
       tufMirror:
         description: "cosign TUF root mirror URL. If not specified, cosign initialize will not be invoked"
         default: ""
@@ -79,6 +83,40 @@ jobs:
             --artifact-digest ${{ needs.push.outputs.digest }} \
             --rekor-url ${{ inputs.rekorUrl }} \
             --fulcio-url ${{ inputs.fulcioUrl }}
+
+  sbom:
+    permissions:
+      id-token: write # used to sign attestations
+      contents: read # for reading local TUF root.json file
+      packages: write # used to push attestations to GHCR
+    concurrency: attestations-${{ github.ref }}
+    runs-on: ubuntu-latest
+    needs: [push]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cosign Setup
+        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
+        with:
+          tufRoot: ${{ inputs.tufRoot }}
+          tufMirror: ${{ inputs.tufMirror }}
+          version: ${{ inputs.cosignVersion }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: anchore/download-syft@v0
+        with:
+          syft-version: ${{ inputs.syftVersion }}
+
+      - name: Generate SBOM
+        run: |
+          syft attest -o spdx-json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
   build:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -114,7 +114,7 @@ jobs:
         with:
           syft-version: ${{ inputs.syftVersion }}
 
-      - name: Generate SBOM
+      - name: Generate SPDX SBOM
         env:
           SYFT_FILE_METADATA_CATALOGER_ENABLED: true
           SYFT_FILE_METADATA_DIGESTS: sha256
@@ -129,6 +129,23 @@ jobs:
             ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
           rm sbom.spdx.json
+
+      - name: Generate CycloneDX SBOM
+        env:
+          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+          SYFT_FILE_METADATA_DIGESTS: sha256
+        run: |
+          syft -o cyclonedx-json --file sbom.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          cosign attest --predicate="sbom.json" \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --type cyclonedx \
+            --fulcio-url ${{ inputs.fulcioUrl }} \
+            --yes \
+            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          rm sbom.json
+
 
   build:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -47,7 +47,7 @@ jobs:
       contents: read # necessary for Git history
       packages: write # used to push attestations to GHCR
       pull-requests: read # used to populate attestation fields
-    concurrency: attestations-${{ github.run_id }}
+    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:
@@ -89,7 +89,7 @@ jobs:
       id-token: write # used to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # used to push attestations to GHCR
-    concurrency: attestations-${{ github.run_id }}
+    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:
@@ -116,7 +116,16 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          syft ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          cosign attest --predicate="sbom.spdx.json" \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --type spdxjson \
+            --fulcio-url ${{ inputs.fulcioUrl }} \
+            --yes \
+            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          rm sbom.spdx.json
 
   build:
     permissions:
@@ -196,7 +205,7 @@ jobs:
       id-token: write # required to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # required to upload attestations to GHCR
-    concurrency: attestations-${{ github.run_id }}
+    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Generate SBOM
         env:
           SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-          SYFT_FILE_METADATA_DIGESTS: sha1
+          SYFT_FILE_METADATA_DIGESTS: sha256
         run: |
           syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -47,7 +47,7 @@ jobs:
       contents: read # necessary for Git history
       packages: write # used to push attestations to GHCR
       pull-requests: read # used to populate attestation fields
-    concurrency: attestations-${{ github.ref }}
+    concurrency: attestations-${{ github.run_id }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:
@@ -89,7 +89,7 @@ jobs:
       id-token: write # used to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # used to push attestations to GHCR
-    concurrency: attestations-${{ github.ref }}
+    concurrency: attestations-${{ github.run_id }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:
@@ -196,7 +196,7 @@ jobs:
       id-token: write # required to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # required to upload attestations to GHCR
-    concurrency: attestations-${{ github.ref }}
+    concurrency: attestations-${{ github.run_id }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -167,7 +167,7 @@ jobs:
             --type spdxjson \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+            ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
 
           rm sbom.spdx.json
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -41,112 +41,6 @@ on:
         value: ${{ jobs.build.outputs.digest }}
 
 jobs:
-  source-attestations:
-    permissions:
-      id-token: write # used to sign attestations
-      contents: read # necessary for Git history
-      packages: write # used to push attestations to GHCR
-      pull-requests: read # used to populate attestation fields
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Cosign Setup
-        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
-        with:
-          tufRoot: ${{ inputs.tufRoot }}
-          tufMirror: ${{ inputs.tufMirror }}
-          version: ${{ inputs.cosignVersion }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Attestor Install
-        uses: liatrio/gh-trusted-builds-workflows/.github/actions/attestor@main
-        with:
-          version: ${{ inputs.attestorVersion }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull Request Attestation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          attestation github-pull-request \
-            --artifact-uri ghcr.io/${{ github.repository }} \
-            --artifact-digest ${{ needs.push.outputs.digest }} \
-            --rekor-url ${{ inputs.rekorUrl }} \
-            --fulcio-url ${{ inputs.fulcioUrl }}
-
-#  sbom:
-#    permissions:
-#      id-token: write # used to sign attestations
-#      contents: read # for reading local TUF root.json file
-#      packages: write # used to push attestations to GHCR
-#    runs-on: ubuntu-latest
-#    needs:
-#      - build
-#      - provenance # prevent race conditions when updating attestation tag
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Cosign Setup
-#        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
-#        with:
-#          tufRoot: ${{ inputs.tufRoot }}
-#          tufMirror: ${{ inputs.tufMirror }}
-#          version: ${{ inputs.cosignVersion }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - uses: anchore/sbom-action/download-syft@v0
-#        with:
-#          syft-version: ${{ inputs.syftVersion }}
-#
-#      - name: Generate SPDX SBOM
-#        env:
-#          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-#          SYFT_FILE_METADATA_DIGESTS: sha256
-#        run: |
-#          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-#
-#          cosign attest --predicate="sbom.spdx.json" \
-#            --rekor-url ${{ inputs.rekorUrl }} \
-#            --type spdxjson \
-#            --fulcio-url ${{ inputs.fulcioUrl }} \
-#            --yes \
-#            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-#
-#          rm sbom.spdx.json
-#
-#      - name: Generate CycloneDX SBOM
-#        env:
-#          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-#          SYFT_FILE_METADATA_DIGESTS: sha256
-#        run: |
-#          syft -o cyclonedx-json --file sbom.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-#
-#          cosign attest --predicate="sbom.json" \
-#            --rekor-url ${{ inputs.rekorUrl }} \
-#            --type cyclonedx \
-#            --fulcio-url ${{ inputs.fulcioUrl }} \
-#            --yes \
-#            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-#
-#          rm sbom.json
-
-
   build:
     permissions:
       contents: read # required to build the container image
@@ -185,50 +79,97 @@ jobs:
         with:
           context: .
           push: true
-          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-#          outputs: type=oci,dest=/tmp/image.tar
 
-#      - name: Upload Image Archive
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: image
-#          path: /tmp/image.tar
+  source-attestations:
+    permissions:
+      id-token: write # used to sign attestations
+      contents: read # necessary for Git history
+      packages: write # used to push attestations to GHCR
+      pull-requests: read # used to populate attestation fields
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-#  push:
-#    permissions:
-#      packages: write # required to push the image to GHCR
-#    runs-on: ubuntu-latest
-#    needs: [build]
-#    outputs:
-#      digest: ${{ steps.push.outputs.digest }}
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Download Image Archive
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: image
-#          path: /tmp
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Load & Push Image
-#        id: push
-#        run: |
-#          docker load --input /tmp/image.tar
-#          image='ghcr.io/${{ github.repository }}'
-#          docker push -a $image
-#          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${image}@" '{print $2}')
-#          echo "image digest: ${digest}"
-#          echo "digest=${digest}" >> $GITHUB_OUTPUT
+      - name: Cosign Setup
+        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
+        with:
+          tufRoot: ${{ inputs.tufRoot }}
+          tufMirror: ${{ inputs.tufMirror }}
+          version: ${{ inputs.cosignVersion }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attestor Install
+        uses: liatrio/gh-trusted-builds-workflows/.github/actions/attestor@main
+        with:
+          version: ${{ inputs.attestorVersion }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Request Attestation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          attestation github-pull-request \
+            --artifact-uri ghcr.io/${{ github.repository }} \
+            --artifact-digest ${{ needs.build.outputs.digest }} \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --fulcio-url ${{ inputs.fulcioUrl }}
+
+  sbom:
+    permissions:
+      id-token: write # used to sign attestations
+      contents: read # for reading local TUF root.json file
+      packages: write # used to push attestations to GHCR
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - provenance # prevent race conditions when updating attestation tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cosign Setup
+        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
+        with:
+          tufRoot: ${{ inputs.tufRoot }}
+          tufMirror: ${{ inputs.tufMirror }}
+          version: ${{ inputs.cosignVersion }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: anchore/sbom-action/download-syft@v0
+        with:
+          syft-version: ${{ inputs.syftVersion }}
+
+      - name: Generate SPDX SBOM
+        env:
+          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+          SYFT_FILE_METADATA_DIGESTS: sha256
+        run: |
+          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
+
+          cosign attest --predicate="sbom.spdx.json" \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --type spdxjson \
+            --fulcio-url ${{ inputs.fulcioUrl }} \
+            --yes \
+            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          rm sbom.spdx.json
 
   provenance:
     permissions:
@@ -287,7 +228,7 @@ jobs:
             --type slsaprovenance \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+            ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
 
   sign:
     permissions:
@@ -321,4 +262,4 @@ jobs:
               --annotations liatr.io/signed-off-by=platform-team \
               --rekor-url ${{ inputs.rekorUrl }} \
               --fulcio-url ${{ inputs.fulcioUrl }} \
-              --yes ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+              --yes ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -47,7 +47,6 @@ jobs:
       contents: read # necessary for Git history
       packages: write # used to push attestations to GHCR
       pull-requests: read # used to populate attestation fields
-    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs: [push]
     steps:
@@ -89,9 +88,10 @@ jobs:
       id-token: write # used to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # used to push attestations to GHCR
-    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
-    needs: [push]
+    needs:
+      - push
+      - provenance # prevent race conditions when updating attestation tag
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -115,6 +115,9 @@ jobs:
           syft-version: ${{ inputs.syftVersion }}
 
       - name: Generate SBOM
+        env:
+          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+          SYFT_FILE_METADATA_DIGESTS: sha1
         run: |
           syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
@@ -207,7 +210,9 @@ jobs:
       packages: write # required to upload attestations to GHCR
     concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
-    needs: [push]
+    needs:
+     - push
+     - source-attestations # prevent race conditions when updating attestation tag
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -38,7 +38,7 @@ on:
     outputs:
       digest:
         description: "Docker image digest"
-        value: ${{ jobs.push.outputs.digest }}
+        value: ${{ jobs.build.outputs.digest }}
 
 jobs:
   source-attestations:
@@ -48,7 +48,7 @@ jobs:
       packages: write # used to push attestations to GHCR
       pull-requests: read # used to populate attestation fields
     runs-on: ubuntu-latest
-    needs: [push]
+    needs: [build]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,25 +83,80 @@ jobs:
             --rekor-url ${{ inputs.rekorUrl }} \
             --fulcio-url ${{ inputs.fulcioUrl }}
 
-  sbom:
+#  sbom:
+#    permissions:
+#      id-token: write # used to sign attestations
+#      contents: read # for reading local TUF root.json file
+#      packages: write # used to push attestations to GHCR
+#    runs-on: ubuntu-latest
+#    needs:
+#      - build
+#      - provenance # prevent race conditions when updating attestation tag
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Cosign Setup
+#        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
+#        with:
+#          tufRoot: ${{ inputs.tufRoot }}
+#          tufMirror: ${{ inputs.tufMirror }}
+#          version: ${{ inputs.cosignVersion }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - uses: anchore/sbom-action/download-syft@v0
+#        with:
+#          syft-version: ${{ inputs.syftVersion }}
+#
+#      - name: Generate SPDX SBOM
+#        env:
+#          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+#          SYFT_FILE_METADATA_DIGESTS: sha256
+#        run: |
+#          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+#
+#          cosign attest --predicate="sbom.spdx.json" \
+#            --rekor-url ${{ inputs.rekorUrl }} \
+#            --type spdxjson \
+#            --fulcio-url ${{ inputs.fulcioUrl }} \
+#            --yes \
+#            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+#
+#          rm sbom.spdx.json
+#
+#      - name: Generate CycloneDX SBOM
+#        env:
+#          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+#          SYFT_FILE_METADATA_DIGESTS: sha256
+#        run: |
+#          syft -o cyclonedx-json --file sbom.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+#
+#          cosign attest --predicate="sbom.json" \
+#            --rekor-url ${{ inputs.rekorUrl }} \
+#            --type cyclonedx \
+#            --fulcio-url ${{ inputs.fulcioUrl }} \
+#            --yes \
+#            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+#
+#          rm sbom.json
+
+
+  build:
     permissions:
-      id-token: write # used to sign attestations
-      contents: read # for reading local TUF root.json file
-      packages: write # used to push attestations to GHCR
+      contents: read # required to build the container image
+      packages: write # required to push the image to GHCR
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-latest
-    needs:
-      - push
-      - provenance # prevent race conditions when updating attestation tag
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Cosign Setup
-        uses: liatrio/gh-trusted-builds-workflows/.github/actions/cosign@main
-        with:
-          tufRoot: ${{ inputs.tufRoot }}
-          tufMirror: ${{ inputs.tufMirror }}
-          version: ${{ inputs.cosignVersion }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -109,51 +164,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: anchore/sbom-action/download-syft@v0
-        with:
-          syft-version: ${{ inputs.syftVersion }}
-
-      - name: Generate SPDX SBOM
-        env:
-          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-          SYFT_FILE_METADATA_DIGESTS: sha256
-        run: |
-          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-
-          cosign attest --predicate="sbom.spdx.json" \
-            --rekor-url ${{ inputs.rekorUrl }} \
-            --type spdxjson \
-            --fulcio-url ${{ inputs.fulcioUrl }} \
-            --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-
-          rm sbom.spdx.json
-
-      - name: Generate CycloneDX SBOM
-        env:
-          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-          SYFT_FILE_METADATA_DIGESTS: sha256
-        run: |
-          syft -o cyclonedx-json --file sbom.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-
-          cosign attest --predicate="sbom.json" \
-            --rekor-url ${{ inputs.rekorUrl }} \
-            --type cyclonedx \
-            --fulcio-url ${{ inputs.fulcioUrl }} \
-            --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
-
-          rm sbom.json
-
-
-  build:
-    permissions:
-      contents: read # required to build the container image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -174,51 +184,51 @@ jobs:
         id: build
         with:
           context: .
-          push: false
+          push: true
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=oci,dest=/tmp/image.tar
+#          outputs: type=oci,dest=/tmp/image.tar
 
-      - name: Upload Image Archive
-        uses: actions/upload-artifact@v3
-        with:
-          name: image
-          path: /tmp/image.tar
+#      - name: Upload Image Archive
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: image
+#          path: /tmp/image.tar
 
-  push:
-    permissions:
-      packages: write # required to push the image to GHCR
-    runs-on: ubuntu-latest
-    needs: [build]
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download Image Archive
-        uses: actions/download-artifact@v3
-        with:
-          name: image
-          path: /tmp
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Load & Push Image
-        id: push
-        run: |
-          docker load --input /tmp/image.tar
-          image='ghcr.io/${{ github.repository }}'
-          docker push -a $image
-          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${image}@" '{print $2}')
-          echo "image digest: ${digest}"
-          echo "digest=${digest}" >> $GITHUB_OUTPUT
+#  push:
+#    permissions:
+#      packages: write # required to push the image to GHCR
+#    runs-on: ubuntu-latest
+#    needs: [build]
+#    outputs:
+#      digest: ${{ steps.push.outputs.digest }}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Download Image Archive
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: image
+#          path: /tmp
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Load & Push Image
+#        id: push
+#        run: |
+#          docker load --input /tmp/image.tar
+#          image='ghcr.io/${{ github.repository }}'
+#          docker push -a $image
+#          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${image}@" '{print $2}')
+#          echo "image digest: ${digest}"
+#          echo "digest=${digest}" >> $GITHUB_OUTPUT
 
   provenance:
     permissions:
@@ -229,7 +239,7 @@ jobs:
     concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs:
-     - push
+     - build
      - source-attestations # prevent race conditions when updating attestation tag
     steps:
       - name: Checkout
@@ -285,7 +295,7 @@ jobs:
       contents: read # for reading local TUF root.json file
       packages: write # required to upload signature to GHCR
     runs-on: ubuntu-latest
-    needs: [push]
+    needs: [build]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/policy-verification.yaml
+++ b/.github/workflows/policy-verification.yaml
@@ -87,7 +87,7 @@ jobs:
           attestation vsa \
             --artifact-uri ghcr.io/${{ github.repository }} \
             --artifact-digest ${{ inputs.digest }} \
-            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.1.1/bundle.tar.gz" \
+            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.2.0/bundle.tar.gz" \
             --verifier-id ${{ github.server_url }}/${{ needs.metadata.outputs.jobWorkflowRef }} \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --rekor-url ${{ inputs.rekorUrl }}


### PR DESCRIPTION
## Changes

- Add `sbom` job in `build-and-push` workflow, to create sbom attestation on the built image.
- Combine `build` and `push` jobs within the workflow, as the access reason for separation is no longer valid.
- Update policy version, to include check for sbom attestation existance.