### PR TITLE
feat: separate build and push jobs

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -38,7 +38,7 @@ on:
     outputs:
       digest:
         description: "Docker image digest"
-        value: ${{ jobs.build.outputs.digest }}
+        value: ${{ jobs.push.outputs.digest }}
 
 jobs:
   detect-workflow:
@@ -57,20 +57,10 @@ jobs:
   build:
     permissions:
       contents: read # required to build the container image
-      packages: write # required to push the image to GHCR
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -88,44 +78,33 @@ jobs:
 
       - name: Build Image
         uses: docker/build-push-action@v4
-        id: build
         with:
           context: .
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/image.tar
 
-  source-attestations:
+      - name: Upload Image Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: image
+          path: /tmp/image.tar
+
+  push:
     permissions:
-      id-token: write # used to sign attestations
-      contents: read # necessary for Git history
-      packages: write # used to push attestations to GHCR
-      pull-requests: read # used to populate attestation fields
+      packages: write # required to push the image to GHCR
     runs-on: ubuntu-latest
-    needs: [build, detect-workflow]
-    defaults:
-      run:
-        working-directory: ./app
+    needs:
+      - build
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
-      - name: Checkout App Repo
-        uses: actions/checkout@v3
+      - name: Download Image Archive
+        uses: actions/download-artifact@v3
         with:
-          path: app
-
-      - name: Checkout Workflows Repo
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: ${{ needs.detect-workflow.outputs.ref }}
-          path: gh-trusted-builds-workflows
-          persist-credentials: false
-
-      - name: Cosign Setup
-        uses: ./gh-trusted-builds-workflows/.github/actions/cosign
-        with:
-          tufRoot: ${{ inputs.tufRoot }}
-          tufMirror: ${{ inputs.tufMirror }}
-          version: ${{ inputs.cosignVersion }}
+          name: image
+          path: /tmp
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -134,31 +113,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attestor Install
-        uses: ./gh-trusted-builds-workflows/.github/actions/attestor
-        with:
-          version: ${{ inputs.attestorVersion }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull Request Attestation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Load & Push Image
+        id: push
         run: |
-          attestation github-pull-request \
-            --artifact-uri ghcr.io/${{ github.repository }} \
-            --artifact-digest ${{ needs.build.outputs.digest }} \
-            --rekor-url ${{ inputs.rekorUrl }} \
-            --fulcio-url ${{ inputs.fulcioUrl }}
+          docker load --input /tmp/image.tar
+          image='ghcr.io/${{ github.repository }}'
+          docker push -a $image
+          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${image}@" '{print $2}')
+          echo "image digest: ${digest}"
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
 
-  sbom:
+  sign:
     permissions:
-      id-token: write # used to sign attestations
+      id-token: write # required to sign image
       contents: read # for reading local TUF root.json file
-      packages: write # used to push attestations to GHCR
+      packages: write # required to upload signature to GHCR
     runs-on: ubuntu-latest
     needs:
-      - build
-      - provenance # prevent race conditions when updating attestation tag
+      - push
       - detect-workflow
     defaults:
       run:
@@ -191,25 +163,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: anchore/sbom-action/download-syft@v0
-        with:
-          syft-version: ${{ inputs.syftVersion }}
-
-      - name: Generate SPDX SBOM
-        env:
-          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
-          SYFT_FILE_METADATA_DIGESTS: sha256
+      - name: Sign
         run: |
-          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
+          cosign sign \
+              --annotations liatr.io/github-actions-run-link='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              --annotations liatr.io/signed-off-by=platform-team \
+              --rekor-url ${{ inputs.rekorUrl }} \
+              --fulcio-url ${{ inputs.fulcioUrl }} \
+              --yes ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
-          cosign attest --predicate="sbom.spdx.json" \
-            --rekor-url ${{ inputs.rekorUrl }} \
-            --type spdxjson \
-            --fulcio-url ${{ inputs.fulcioUrl }} \
-            --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
-
-          rm sbom.spdx.json
 
   provenance:
     permissions:
@@ -217,12 +179,10 @@ jobs:
       id-token: write # required to sign attestations
       contents: read # for reading local TUF root.json file
       packages: write # required to upload attestations to GHCR
-    concurrency: attestations-${{ github.ref }}
     runs-on: ubuntu-latest
     needs:
-     - build
-     - source-attestations # prevent race conditions when updating attestation tag
-     - detect-workflow
+      - push
+      - detect-workflow
     defaults:
       run:
         working-directory: ./app
@@ -282,15 +242,19 @@ jobs:
             --type slsaprovenance \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --yes \
-            ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
+            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
 
-  sign:
+
+  sbom:
     permissions:
-      id-token: write # required to sign image
+      id-token: write # used to sign attestations
       contents: read # for reading local TUF root.json file
-      packages: write # required to upload signature to GHCR
+      packages: write # used to push attestations to GHCR
     runs-on: ubuntu-latest
-    needs: [build, detect-workflow]
+    needs:
+      - push
+      - detect-workflow
+      - provenance # prevent race conditions when updating attestation tag
     defaults:
       run:
         working-directory: ./app
@@ -322,11 +286,81 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sign
+      - uses: anchore/sbom-action/download-syft@v0
+        with:
+          syft-version: ${{ inputs.syftVersion }}
+
+      - name: Generate SPDX SBOM
+        env:
+          SYFT_FILE_METADATA_CATALOGER_ENABLED: true
+          SYFT_FILE_METADATA_DIGESTS: sha256
         run: |
-          cosign sign \
-              --annotations liatr.io/github-actions-run-link='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
-              --annotations liatr.io/signed-off-by=platform-team \
-              --rekor-url ${{ inputs.rekorUrl }} \
-              --fulcio-url ${{ inputs.fulcioUrl }} \
-              --yes ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
+          syft -o spdx-json --file sbom.spdx.json ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          cosign attest --predicate="sbom.spdx.json" \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --type spdxjson \
+            --fulcio-url ${{ inputs.fulcioUrl }} \
+            --yes \
+            ghcr.io/${{ github.repository }}@${{ needs.push.outputs.digest }}
+
+          rm sbom.spdx.json
+
+  source-attestations:
+    permissions:
+      id-token: write # used to sign attestations
+      contents: read # necessary for Git history
+      packages: write # used to push attestations to GHCR
+      pull-requests: read # used to populate attestation fields
+    runs-on: ubuntu-latest
+    needs:
+      - push
+      - detect-workflow
+      - sbom # prevent race conditions when updating attestation tag
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+      - name: Checkout App Repo
+        uses: actions/checkout@v3
+        with:
+          path: app
+
+      - name: Checkout Workflows Repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ needs.detect-workflow.outputs.repository }}
+          ref: ${{ needs.detect-workflow.outputs.ref }}
+          path: gh-trusted-builds-workflows
+          persist-credentials: false
+
+      - name: Cosign Setup
+        uses: ./gh-trusted-builds-workflows/.github/actions/cosign
+        with:
+          tufRoot: ${{ inputs.tufRoot }}
+          tufMirror: ${{ inputs.tufMirror }}
+          version: ${{ inputs.cosignVersion }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attestor Install
+        uses: ./gh-trusted-builds-workflows/.github/actions/attestor
+        with:
+          version: ${{ inputs.attestorVersion }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Request Attestation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          attestation github-pull-request \
+            --artifact-uri ghcr.io/${{ github.repository }} \
+            --artifact-digest ${{ needs.push.outputs.digest }} \
+            --rekor-url ${{ inputs.rekorUrl }} \
+            --fulcio-url ${{ inputs.fulcioUrl }}
+          


### PR DESCRIPTION
Separating the build and push jobs again, to better support token permission control for different scenarios.

Also removed lingering `concurrency` usage for attestation jobs.