### PR TITLE
build: bump attestor & policy version

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       attestorVersion:
         description: "liatrio/gh-trusted-builds-attestations version"
-        default: "1.0.0"
+        default: "1.1.0"
         type: string
       cosignVersion:
         description: "Sigstore cosign version"

--- a/.github/workflows/policy-verification.yaml
+++ b/.github/workflows/policy-verification.yaml
@@ -101,7 +101,7 @@ jobs:
           attestation vsa \
             --artifact-uri ghcr.io/${{ github.repository }} \
             --artifact-digest ${{ inputs.digest }} \
-            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.3.0/bundle.tar.gz" \
+            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.4.0/bundle.tar.gz" \
             --verifier-id ${{ github.server_url }}/${{ needs.detect-workflow.outputs.repository }}/${{ needs.detect-workflow.outputs.workflow }}@${{ needs.detect-workflow.outputs.ref }} \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --rekor-url ${{ inputs.rekorUrl }}

--- a/.github/workflows/policy-verification.yaml
+++ b/.github/workflows/policy-verification.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       attestorVersion:
         description: "liatrio/gh-trusted-builds-attestations version"
-        default: "1.0.0"
+        default: "1.1.0"
         type: string
       cosignVersion:
         description: "Sigstore cosign version"
@@ -101,7 +101,7 @@ jobs:
           attestation vsa \
             --artifact-uri ghcr.io/${{ github.repository }} \
             --artifact-digest ${{ inputs.digest }} \
-            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.2.0/bundle.tar.gz" \
+            --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.3.0/bundle.tar.gz" \
             --verifier-id ${{ github.server_url }}/${{ needs.detect-workflow.outputs.repository }}/${{ needs.detect-workflow.outputs.workflow }}@${{ needs.detect-workflow.outputs.ref }} \
             --fulcio-url ${{ inputs.fulcioUrl }} \
             --rekor-url ${{ inputs.rekorUrl }}


### PR DESCRIPTION
Depends on the release of https://github.com/liatrio/gh-trusted-builds-policy/pull/6