### PR TITLE
feat: compute image digest locally

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -62,6 +62,8 @@ jobs:
     permissions:
       contents: read # required to build the container image
     runs-on: ubuntu-latest
+    outputs:
+      metadata: ${{ steps.meta.outputs.json }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
@@ -104,11 +106,6 @@ jobs:
       - build
     outputs:
       digest: ${{ steps.push.outputs.digest }}
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
       - name: Download Image Archive
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
@@ -143,16 +140,41 @@ jobs:
       - name: Load & Push Image
         id: push
         run: |
-          localImage='localhost:5000/${{ github.repository }}'
-          remoteImage='ghcr.io/${{ github.repository }}'
+          image="ghcr.io/${{ github.repository }}"
 
-          crane push --image-refs=push.log /tmp/image.tar "${localImage}"
-          digest=$(awk -F "${localImage}@" '{print $2}' < push.log)
+          localDigest=$(crane digest --tarball /tmp/image.tar)
+          echo "locally-computed digest: ${localDigest}"
 
-          echo "image digest: ${digest}"
-          echo "digest=${digest}" >> $GITHUB_OUTPUT
+          printf "${{ needs.build.outputs.metadata }}" > metadata.json
+          cat metadata.json
 
-          crane copy -a -v "${localImage}" "${remoteImage}"
+          pushedImage=$(jq -r '.tags[0]' < metadata.json)
+          echo "Pushing ${pushedImage}"
+          crane push --image-refs=push.log /tmp/image.tar "${pushedImage}"
+
+          registryDigest=$(awk -F "${image}@" '{print $2}' < push.log)
+          if [[ "${localDigest}" == "${registryDigest}" ]]; then
+             echo "Remote digest matches digest from local registry"
+          else
+            echo "Digest in registry doesn't match expected digest"
+            echo "Locally-computed digest: ${localDigest}"
+            echo "Digest from registry: ${registryDigest}"
+            echo "This may indicate the image was modified by the registry"
+            exit 1
+          fi
+
+          # add the remaining tags, skipping the tag that was pushed initially
+          jq -rc '.tags | .[]' < metadata.json | while read taggedImage; do
+            if [[ "${taggedImage}" == "${pushedImage}" ]]; then
+              continue
+            fi
+
+            tag=$(printf "${taggedImage}" | awk -F "${image}:" '{print $2}')
+            echo "adding tag ${tag}"
+            crane tag "${pushedImage}" "${tag}"
+          done
+
+          echo "digest=${localDigest}" >> $GITHUB_OUTPUT
 
   sign:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -7,6 +7,10 @@ on:
         description: "liatrio/gh-trusted-builds-attestations version"
         default: "1.1.0"
         type: string
+      craneVersion:
+        description: "google/go-containerregistry crane version"
+        default: "v0.15.2"
+        type: string
       cosignVersion:
         description: "Sigstore cosign version"
         default: "v2.0.2"
@@ -99,6 +103,11 @@ jobs:
       - build
     outputs:
       digest: ${{ steps.push.outputs.digest }}
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Download Image Archive
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
@@ -113,15 +122,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Crane
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd $(mktemp -d)
+
+          gh release download \
+          --repo google/go-containerregistry \
+          --pattern "go-containerregistry_Linux_arm64.tar.gz" "${{ inputs.version }}"
+
+          mkdir -p $HOME/.bin/crane
+          mv ./crane $HOME/.bin/crane
+          echo "$HOME/.bin/crane" >> $GITHUB_PATH
+          $HOME/.bin/crane/crane version
+
       - name: Load & Push Image
         id: push
         run: |
           docker load --input /tmp/image.tar
-          image='ghcr.io/${{ github.repository }}'
-          docker push -a $image
-          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${image}@" '{print $2}')
+
+          localImage='registry:5000/${{ github.repository }}'
+          remoteImage='ghcr.io/${{ github.repository }}'
+          docker push -a "${localImage}"
+
+          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${localImage}@" '{print $2}')
           echo "image digest: ${digest}"
           echo "digest=${digest}" >> $GITHUB_OUTPUT
+
+          crane copy -v "${localImage}" "${remoteImage}"
 
   sign:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -148,13 +148,13 @@ jobs:
 
           localImage='registry:5000/${{ github.repository }}'
           remoteImage='ghcr.io/${{ github.repository }}'
-          crane push "${localImage}"
+          crane push --insecure /tmp/image.tar "${localImage}"
 
           digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${localImage}@" '{print $2}')
           echo "image digest: ${digest}"
           echo "digest=${digest}" >> $GITHUB_OUTPUT
 
-          crane copy -v "${localImage}" "${remoteImage}"
+          crane copy --insecure -v "${localImage}" "${remoteImage}"
 
   sign:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -148,7 +148,7 @@ jobs:
 
           localImage='registry:5000/${{ github.repository }}'
           remoteImage='ghcr.io/${{ github.repository }}'
-          docker push -a "${localImage}"
+          crane push "${localImage}"
 
           digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${localImage}@" '{print $2}')
           echo "image digest: ${digest}"

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -74,7 +74,6 @@ jobs:
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4
         with:
           images: |
-            registry:5000/${{ github.repository }}
             ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
@@ -146,7 +145,7 @@ jobs:
         run: |
           docker load --input /tmp/image.tar
 
-          localImage='registry:5000/${{ github.repository }}'
+          localImage='localhost:5000/${{ github.repository }}'
           remoteImage='ghcr.io/${{ github.repository }}'
           crane push --insecure /tmp/image.tar "${localImage}"
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -148,7 +148,8 @@ jobs:
         env:
           IMAGE_METADATA: ${{ needs.build.outputs.metadata }}
         run: |
-          pushedImage=$(printf "${IMAGE_METADATA}" | jq -r '.tags[0]')
+          commit=$(git rev-parse --short HEAD)
+          pushedImage=$(printf "${IMAGE_METADATA}" | jq --arg commit "${commit}" -r '.tags | .[] | select(.|endswith($commit))')
           echo "Pushing ${pushedImage}"
           crane push /tmp/image.tar "${pushedImage}"
           echo "image=${pushedImage}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -139,16 +139,15 @@ jobs:
 
       - name: Load & Push Image
         id: push
+        env:
+          IMAGE_METADATA: ${{ needs.build.outputs.metadata }}
         run: |
           image="ghcr.io/${{ github.repository }}"
 
           localDigest=$(crane digest --tarball /tmp/image.tar)
           echo "locally-computed digest: ${localDigest}"
 
-          printf "${{ needs.build.outputs.metadata }}" > metadata.json
-          cat metadata.json
-
-          pushedImage=$(jq -r '.tags[0]' < metadata.json)
+          pushedImage=$(printf "${IMAGE_METADATA}" | jq -r '.tags[0]')
           echo "Pushing ${pushedImage}"
           crane push --image-refs=push.log /tmp/image.tar "${pushedImage}"
 
@@ -164,7 +163,7 @@ jobs:
           fi
 
           # add the remaining tags, skipping the tag that was pushed initially
-          jq -rc '.tags | .[]' < metadata.json | while read taggedImage; do
+          printf "${IMAGE_METADATA}" | jq -rc '.tags | .[]' | while read taggedImage; do
             if [[ "${taggedImage}" == "${pushedImage}" ]]; then
               continue
             fi

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -143,17 +143,16 @@ jobs:
       - name: Load & Push Image
         id: push
         run: |
-          docker load --input /tmp/image.tar
-
           localImage='localhost:5000/${{ github.repository }}'
           remoteImage='ghcr.io/${{ github.repository }}'
-          crane push --insecure /tmp/image.tar "${localImage}"
 
-          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${image}" | awk -F "${localImage}@" '{print $2}')
+          crane push --image-refs=push.log /tmp/image.tar "${localImage}"
+          digest=$(awk -F "${localImage}@" '{print $2}' < push.log)
+
           echo "image digest: ${digest}"
           echo "digest=${digest}" >> $GITHUB_OUTPUT
 
-          crane copy --insecure -v "${localImage}" "${remoteImage}"
+          crane copy -a -v "${localImage}" "${remoteImage}"
 
   sign:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -132,6 +132,8 @@ jobs:
           --repo google/go-containerregistry \
           --pattern "go-containerregistry_Linux_arm64.tar.gz" "${{ inputs.version }}"
 
+          tar xvf go-containerregistry_Linux_arm64.tar.gz
+
           mkdir -p $HOME/.bin/crane
           mv ./crane $HOME/.bin/crane
           echo "$HOME/.bin/crane" >> $GITHUB_PATH

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -75,8 +75,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -105,7 +104,7 @@ jobs:
     needs:
       - build
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
     steps:
       - name: Download Image Archive
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
@@ -137,30 +136,44 @@ jobs:
           echo "$HOME/.bin/crane" >> $GITHUB_PATH
           $HOME/.bin/crane/crane version
 
-      - name: Load & Push Image
+      - name: Compute Digest
+        id: digest
+        run: |
+          localDigest=$(crane digest --tarball /tmp/image.tar)
+          echo "locally-computed digest: ${localDigest}"
+          echo "digest=${localDigest}" >> $GITHUB_OUTPUT
+
+      - name: Push Image
         id: push
         env:
           IMAGE_METADATA: ${{ needs.build.outputs.metadata }}
         run: |
-          image="ghcr.io/${{ github.repository }}"
-
-          localDigest=$(crane digest --tarball /tmp/image.tar)
-          echo "locally-computed digest: ${localDigest}"
-
           pushedImage=$(printf "${IMAGE_METADATA}" | jq -r '.tags[0]')
           echo "Pushing ${pushedImage}"
-          crane push --image-refs=push.log /tmp/image.tar "${pushedImage}"
+          crane push /tmp/image.tar "${pushedImage}"
+          echo "image=${pushedImage}" >> $GITHUB_OUTPUT
 
-          registryDigest=$(awk -F "${image}@" '{print $2}' < push.log)
+      - name: Compare Digests
+        run: |
+          pushedImage=${{ steps.push.outputs.image }}
+          registryDigest=$(crane digest "${pushedImage}")
+          localDigest=${{ steps.digest.outputs.digest }}
+
           if [[ "${localDigest}" == "${registryDigest}" ]]; then
-             echo "Remote digest matches digest from local registry"
+              echo "Remote digest matches digest from local registry"
           else
-            echo "Digest in registry doesn't match expected digest"
-            echo "Locally-computed digest: ${localDigest}"
-            echo "Digest from registry: ${registryDigest}"
-            echo "This may indicate the image was modified by the registry"
-            exit 1
+              echo "Digest in registry doesn't match expected digest"
+              echo "Locally-computed digest: ${localDigest}"
+              echo "Digest from registry: ${registryDigest}"
+              echo "This may indicate the image was modified by the registry"
+              exit 1
           fi
+
+      - name: Add Tags
+        env:
+          IMAGE_METADATA: ${{ needs.build.outputs.metadata }}
+        run: |
+          pushedImage=${{ steps.push.outputs.image }}
 
           # add the remaining tags, skipping the tag that was pushed initially
           printf "${IMAGE_METADATA}" | jq -rc '.tags | .[]' | while read taggedImage; do
@@ -172,8 +185,6 @@ jobs:
             echo "adding tag ${tag}"
             crane tag "${pushedImage}" "${tag}"
           done
-
-          echo "digest=${localDigest}" >> $GITHUB_OUTPUT
 
   sign:
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -148,8 +148,8 @@ jobs:
         env:
           IMAGE_METADATA: ${{ needs.build.outputs.metadata }}
         run: |
-          commit=$(git rev-parse --short HEAD)
-          pushedImage=$(printf "${IMAGE_METADATA}" | jq --arg commit "${commit}" -r '.tags | .[] | select(.|endswith($commit))')
+          commit="${{ github.sha }}"
+          pushedImage=$(printf "${IMAGE_METADATA}" | jq --arg commit "${commit::7}" -r '.tags | .[] | select(.|endswith($commit))')
           echo "Pushing ${pushedImage}"
           crane push /tmp/image.tar "${pushedImage}"
           echo "image=${pushedImage}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -73,7 +73,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            registry:5000/${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -130,9 +130,9 @@ jobs:
 
           gh release download \
           --repo google/go-containerregistry \
-          --pattern "go-containerregistry_Linux_arm64.tar.gz" "${{ inputs.version }}"
+          --pattern "go-containerregistry_Linux_x86_64.tar.gz" "${{ inputs.craneVersion }}"
 
-          tar xvf go-containerregistry_Linux_arm64.tar.gz
+          tar xvf go-containerregistry_Linux_x86_64.tar.gz
 
           mkdir -p $HOME/.bin/crane
           mv ./crane $HOME/.bin/crane


### PR DESCRIPTION
Rather than relying on the registry to tell us the digest, which requires placing additional trust in the registry, this PR uses `crane digest --tarball` to compute the expected digest before pushing. 

AIUI, we can't rely on different tools to produce the same digests, so this PR also changes the push step to use `crane` instead of the Docker cli.  

Example run: https://github.com/liatrio/gh-trusted-builds-app/actions/runs/5282295164