### PR TITLE
test: allow async usage of cosign cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@octokit/auth-app": "5.0.3",
         "@octokit/rest": "19.0.11",
         "adm-zip": "0.5.10",
+        "async": "3.2.4",
         "config": "3.3.9",
         "prettier": "2.8.8"
       }
@@ -336,6 +337,12 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@octokit/auth-app": "5.0.3",
     "@octokit/rest": "19.0.11",
     "adm-zip": "0.5.10",
+    "async": "3.2.4",
     "config": "3.3.9",
     "prettier": "2.8.8"
   }

--- a/test/build-and-push.test.js
+++ b/test/build-and-push.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before } from "node:test";
 import { strict as assert } from "node:assert";
-import { VerifyAttestation } from "./helpers/cosign.js";
+import { verifyAttestation } from "./helpers/cosign.js";
 import { GitHub } from "./helpers/github.js";
 import config from "config";
 
@@ -131,7 +131,7 @@ describe("build and push workflow", () => {
     });
 
     it("should create a valid sbom attestation", async () => {
-      const result = await VerifyAttestation(
+      const result = await verifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "spdxjson",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
@@ -141,7 +141,7 @@ describe("build and push workflow", () => {
     });
 
     it("should create a valid pull request attestation", async () => {
-      const result = await VerifyAttestation(
+      const result = await verifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "https://liatr.io/attestations/github-pull-request/v1",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
@@ -152,7 +152,7 @@ describe("build and push workflow", () => {
     });
 
     it("should create a valid provenance attestation", async () => {
-      const result = await VerifyAttestation(
+      const result = await verifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "slsaprovenance",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",

--- a/test/build-and-push.test.js
+++ b/test/build-and-push.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before } from "node:test";
+import { before, describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 import { verifyAttestation } from "./helpers/cosign.js";
 import { GitHub } from "./helpers/github.js";
@@ -132,33 +132,33 @@ describe("build and push workflow", () => {
 
     it("should create a valid sbom attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
+        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
         "spdxjson",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
-      assert.equal(result.code, 0, result.err);
+      assert.equal(result.status, 0, result.err);
     });
 
     it("should create a valid pull request attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
+        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
         "https://liatr.io/attestations/github-pull-request/v1",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
 
-      assert.equal(result.code, 0, result.err);
+      assert.equal(result.status, 0, result.err);
     });
 
     it("should create a valid provenance attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
+        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
         "slsaprovenance",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
-      assert.equal(result.code, 0, result.err);
+      assert.equal(result.status, 0, result.err);
     });
   });
 });

--- a/test/build-and-push.test.js
+++ b/test/build-and-push.test.js
@@ -1,6 +1,6 @@
-import { before, describe, it } from "node:test";
+import { describe, it, before } from "node:test";
 import { strict as assert } from "node:assert";
-import { cosignVerifyAttestation } from "./helpers/cosign.js";
+import { VerifyAttestation } from "./helpers/cosign.js";
 import { GitHub } from "./helpers/github.js";
 import config from "config";
 
@@ -131,34 +131,34 @@ describe("build and push workflow", () => {
     });
 
     it("should create a valid sbom attestation", async () => {
-      const result = cosignVerifyAttestation(
+      const result = await VerifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "spdxjson",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
-      assert.equal(result.status, 0, result.stderr.toString());
+      assert.equal(result.code, 0, result.err);
     });
 
     it("should create a valid pull request attestation", async () => {
-      const result = cosignVerifyAttestation(
+      const result = await VerifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "https://liatr.io/attestations/github-pull-request/v1",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
 
-      assert.equal(result.status, 0, result.stderr.toString());
+      assert.equal(result.code, 0, result.err);
     });
 
     it("should create a valid provenance attestation", async () => {
-      const result = cosignVerifyAttestation(
+      const result = await VerifyAttestation(
         `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "slsaprovenance",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
       );
-      assert.equal(result.status, 0, result.stderr.toString());
+      assert.equal(result.code, 0, result.err);
     });
   });
 });

--- a/test/build-and-push.test.js
+++ b/test/build-and-push.test.js
@@ -132,7 +132,7 @@ describe("build and push workflow", () => {
 
     it("should create a valid sbom attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
+        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "spdxjson",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
@@ -142,7 +142,7 @@ describe("build and push workflow", () => {
 
     it("should create a valid pull request attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
+        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "https://liatr.io/attestations/github-pull-request/v1",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"
@@ -153,7 +153,7 @@ describe("build and push workflow", () => {
 
     it("should create a valid provenance attestation", async () => {
       const result = await verifyAttestation(
-        `ghcr.io/${owner}/${repo}@sha256:98231220ca50030ae95b0a0ed73945337a4b95930225bddc58bab86f00afb2f0`,
+        `ghcr.io/${owner}/${repo}@${runMetadata.digest}`,
         "slsaprovenance",
         "^https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/.*.yaml@.*",
         "https://token.actions.githubusercontent.com"

--- a/test/helpers/cosign.js
+++ b/test/helpers/cosign.js
@@ -26,7 +26,7 @@ const q = queue((task, callback) => {
   });
 });
 
-export function VerifyAttestation(
+export function verifyAttestation(
   image,
   attestationType,
   certIdentity,

--- a/test/helpers/cosign.js
+++ b/test/helpers/cosign.js
@@ -1,15 +1,38 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { queue } from "async";
 
-// This function is currently synchronous, to avoid local cache lock errors when running cosign in multiple processes at once.
-// Could be improved with something like an async queue to limit global calls to the cosign cli,
-// or be replaced by the Sigstore NPM package if it gains the equivalent features https://github.com/sigstore/sigstore-js/tree/main/packages/client.
-export function cosignVerifyAttestation(
+// A queue is used to avoid local cache lock errors when running cosign cli in multiple processes at once.
+// This ensures only a single cosign process is running at one time, while remaining asynchronous.
+// The use of cosign cli could be replaced by the Sigstore NPM package,
+// if it gains the equivalent features https://github.com/sigstore/sigstore-js/tree/main/packages/client.
+const q = queue((task, callback) => {
+  const s = spawn("cosign", task.args);
+  let out = "",
+    err = "";
+
+  s.stdout.on("data", (data) => {
+    out += data;
+  });
+
+  s.stderr.on("data", (data) => {
+    err += data;
+  });
+
+  s.on("exit", (code) => {
+    task.code = code;
+    task.out = out;
+    task.err = err;
+    callback();
+  });
+});
+
+export function VerifyAttestation(
   image,
   attestationType,
   certIdentity,
   certOidcIssuer
 ) {
-  return spawnSync("cosign", [
+  const args = [
     "verify-attestation",
     "--type",
     attestationType,
@@ -18,5 +41,17 @@ export function cosignVerifyAttestation(
     "--certificate-oidc-issuer",
     certOidcIssuer,
     image,
-  ]);
+  ];
+
+  const task = { args };
+
+  return new Promise((resolve, reject) => {
+    q.push(task, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(task);
+      }
+    });
+  });
 }


### PR DESCRIPTION
This uses an async queue to control the number of child processes of cosign cli that are spawned. This will allow tests to not have to wait on synchronous calls to the cosign cli.