### PR TITLE
ci: require integration tests before release

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,13 +1,17 @@
 name: Integration Tests
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      concurrencyGroup:
+        type: string
+        required: false
+        default: ${{ github.ref }}
+        description: Name for concurrency group to cancel older, queued test runs
 jobs:
   integration:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ inputs.concurrencyGroup }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,16 +2,18 @@ name: Integration Tests
 on:
   workflow_call:
     inputs:
-      concurrencyGroup:
+      concurrencyGroupTag:
         type: string
         required: false
-        default: ${{ github.ref }}
-        description: Name for concurrency group to cancel older, queued test runs
+        default: ${{ github.ref_name }}
+        description: Tag for integration test concurrency group to cancel older, queued test runs
+
+concurrency:
+  group: integration-test-${{ inputs.concurrencyGroupTag }}
+
 jobs:
   integration:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ inputs.concurrencyGroup }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,17 @@ on:
   push:
     branches:
       - main
+
 jobs:
+  integration:
+    uses: ./.github/workflows/integration-tests.yaml
+    with:
+      concurrencyGroup: ${{ github.sha }} # always run, so releases are not skipped.
+
   release:
     runs-on: ubuntu-latest
+    needs:
+      - integration
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   integration:
     uses: ./.github/workflows/integration-tests.yaml
     with:
-      concurrencyGroup: ${{ github.sha }} # always run, so releases are not skipped.
+      concurrencyGroupTag: ${{ github.sha }} # always run, so releases are not skipped.
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This turns integration tests into a reusable workflow, as a way to make a dependency for the release job. This will also make it easier to reuse integration test config for other branches in pull request checks, if introduced.