### PR TITLE
ci: remove extraneous cosign inputs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,8 +30,6 @@ jobs:
       - name: Cosign Setup
         uses: ./.github/actions/cosign
         with:
-          fulcioUrl: "https://fulcio.sigstage.dev"
-          rekorUrl: "https://rekor.sigstage.dev"
           tufMirror: "https://tuf-repo-cdn.sigstage.dev"
           tufRoot: "test/sigstore/1.root.json"
           version: "v2.0.2"


### PR DESCRIPTION
https://github.com/liatrio/gh-trusted-builds-workflows/actions/runs/5294191012/jobs/9583259266#step:3:4