### PR TITLE
fix: only tag latest when running on the default branch

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -44,8 +44,6 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: ghcr.io/${{ github.repository }}
-          flavor: |
-            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -44,11 +44,13 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=
-            type=raw,value=latest-{{is_default_branch}},enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -48,7 +48,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=
-            latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -48,7 +48,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest-{{is_default_branch}},enable={{is_default_branch}}
 
       - name: Build Image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4


### PR DESCRIPTION
Closes #37 

- [app workflow on a different branch](https://github.com/liatrio/gh-trusted-builds-app/actions/runs/5359361585/jobs/9722863203#step:10:18) - no latest tag
- [integration test run on main](https://github.com/alexashley/gh-trusted-builds-workflows-integration-tests/actions/runs/5359409865/jobs/9722969461#step:10:22) - latest tag is added to the image