### PR TITLE
ci: fix Rekor monitor workflow inputs

### DIFF
--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -7,9 +7,6 @@ on:
 #  schedule:
 #    - cron: '0 * * * *' # hourly
 
-env:
-  GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
-
 jobs:
   run-consistency-proof:
     permissions:
@@ -24,10 +21,10 @@ jobs:
         certIdentities:
           - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/build-and-push\.yaml@.*
             issuers:
-              - ${{ env.GITHUB_ACTIONS_ISSUER }}
+              - https://token.actions.githubusercontent.com
           - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/scan-image\.yaml@.*
             issuers:
-              - ${{ env.GITHUB_ACTIONS_ISSUER }}
+              - https://token.actions.githubusercontent.com
           - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/policy-verification\.yaml@.*
             issuers:
-              - ${{ env.GITHUB_ACTIONS_ISSUER }}
+              - https://token.actions.githubusercontent.com

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -1,11 +1,8 @@
 name: Rekor Monitor
 
 on:
-  push:
-    branches:
-      - fix-rekor-monitor
-#  schedule:
-#    - cron: '0 * * * *' # hourly
+ schedule:
+   - cron: '0 * * * *' # hourly
 
 jobs:
   run-consistency-proof:
@@ -13,7 +10,7 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
+    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@be31d0d7ff5766e27baac1f6029edc07cbf04a54
     with:
       file_issue: true
       artifact_retention_days: 14

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -19,12 +19,12 @@ jobs:
       artifact_retention_days: 14
       identities: |
         certIdentities:
-          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/build-and-push\.yaml@.*
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/\.github/workflows/build-and-push\.yaml@.*
             issuers:
               - https://token.actions.githubusercontent.com
-          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/scan-image\.yaml@.*
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/\.github/workflows/scan-image\.yaml@.*
             issuers:
               - https://token.actions.githubusercontent.com
-          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/policy-verification\.yaml@.*
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/\.github/workflows/policy-verification\.yaml@.*
             issuers:
               - https://token.actions.githubusercontent.com

--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -1,48 +1,33 @@
 name: Rekor Monitor
 
 on:
-  schedule:
-    - cron: '0 * * * *' # hourly
+  push:
+    branches:
+      - fix-rekor-monitor
+#  schedule:
+#    - cron: '0 * * * *' # hourly
 
 env:
   GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
 
 jobs:
-  identities:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    outputs:
-      identities: ${{ steps.workflow.outputs.workflow-identities }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Get Workflow Identities
-        id: workflow
-        env:
-          GITHUB_ACTIONS_ISSUER: "https://token.actions.githubusercontent.com"
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          REPO: ${{ github.repository }}
-        run: |
-          workflows=$(find ./.github/workflows -type f -name '*.yaml' -not \( -name rekor-monitor.yaml \))
-
-          echo 'workflow-identities<<EOF' >> $GITHUB_OUTPUT
-          while read workflow; do
-            workflowName=$(basename "${workflow}")
-            echo "${GITHUB_SERVER_URL}/${REPO}/.github/workflows/${workflowName}@refs/heads/main ${GITHUB_ACTIONS_ISSUER}" >> $GITHUB_OUTPUT
-          done <<< "${workflows}"
-
-          echo 'EOF' >> $GITHUB_OUTPUT
-
   run-consistency-proof:
     permissions:
       contents: read
       issues: write
       id-token: write
-    needs: [identities]
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true
       artifact_retention_days: 14
       identities: |
-        ${{ needs.identities.outputs.identities }}
+        certIdentities:
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/build-and-push\.yaml@.*
+            issuers:
+              - ${{ env.GITHUB_ACTIONS_ISSUER }}
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/scan-image\.yaml@.*
+            issuers:
+              - ${{ env.GITHUB_ACTIONS_ISSUER }}
+          - certSubject: ^${{ github.server_url }}/${{ github.repository }}/.\github/workflows/policy-verification\.yaml@.*
+            issuers:
+              - ${{ env.GITHUB_ACTIONS_ISSUER }}


### PR DESCRIPTION
There was a breaking change to the Rekor monitor reusable workflow a few weeks. Previously, you configured identities to monitor as a list of newline-delimited subjects and issuers, but it's now a YAML document with a new structure.

Successful run: https://github.com/liatrio/gh-trusted-builds-workflows/actions/runs/6262313835

Issue created by the workflow: https://github.com/liatrio/gh-trusted-builds-workflows/issues/69
