### PR TITLE
build: bump gh-trusted-builds-attestations version

### DIFF
--- a/.github/actions/config/action.yaml
+++ b/.github/actions/config/action.yaml
@@ -9,7 +9,7 @@ inputs:
 outputs:
   attestorVersion:
     description: "liatrio/gh-trusted-builds-attestations version"
-    value: "1.1.4"
+    value: "1.1.5"
   cosignVersion:
     description: "Sigstore cosign version"
     value: "v2.2.3"


### PR DESCRIPTION
Dependency updates for cosign and go-git: https://github.com/liatrio/gh-trusted-builds-attestations/pull/32