### PR TITLE
ci: switch Renovate to config:recommended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommits",
     ":semanticCommitTypeAll(build)",
     ":semanticCommitScopeDisabled",


### PR DESCRIPTION
The `config:base` preset was renamed to `config:recommended`. Internally, [Renovate converts the old preset name](https://github.com/renovatebot/renovate/blob/0dfea671b309f14697b042073fed5c25b11382bb/lib/config/presets/common.ts#L17), so this isn't a functional change. 